### PR TITLE
Fix Matrix class to allow for vectors, fix instance variable names

### DIFF
--- a/matrices.py
+++ b/matrices.py
@@ -44,6 +44,8 @@ class Matrix:
         :param other: The matrix on the right side of the operator.
         :return: Returns a matrix object of the product.
         """
+        if isinstance(other, int) or isinstance(other, float):
+            return Matrix([[other * item for item in row] for row in self.arr])
         if self.adim != other.length:
             raise IndexError
         prod = [[0] * other.adim for _ in range(self.length)]

--- a/matrices.py
+++ b/matrices.py
@@ -6,13 +6,16 @@ class Matrix:
     
         :param arr: The array representation of the matrix.
         """
-        if not (arr and all(isinstance(k, list) for k in arr)):
+        if not arr:
             raise IndexError
+        if not all(isinstance(k, list) for k in arr):
+            if all(isinstance(k, int) or isinstance(k, float) for k in arr):
+                arr = [arr]
+            else:
+                raise IndexError
         self.arr = arr
         self.length = len(arr)
-        self.adim = list(str(arr)).count("[")
-        self.n = len(arr[0])
-
+        self.adim = len(arr[0])
 
 
     def __add__(self, other):
@@ -23,13 +26,14 @@ class Matrix:
         :param other: The matrix on the right side of the operator.
         :return: Returns a matrix object of the sum.
         """
-        if self.m != other.m or self.n != other.n:
+        if self.length != other.length or self.adim != other.adim:
             raise IndexError
         sum_matrix = [
-        [self.arr[i][j] + other.arr[i][j] for j in range(self.n)]
-        for i in range(self.m)
+        [self.arr[i][j] + other.arr[i][j] for j in range(self.adim)]
+        for i in range(self.length)
         ]
         return Matrix(sum_matrix)
+
 
     def __mul__(self, other):
         """
@@ -40,14 +44,16 @@ class Matrix:
         :param other: The matrix on the right side of the operator.
         :return: Returns a matrix object of the product.
         """
-        if self.n != other.m:
+        if self.adim != other.length:
             raise IndexError
-        prod = [[0] * other.n for _ in range(self.m)]
-        for i in range(self.m):
-            for j in range(other.n):
-                for k in range(self.n):
+        prod = [[0] * other.adim for _ in range(self.length)]
+        for i in range(self.length):
+            for j in range(other.adim):
+                for k in range(self.adim):
                     prod[i][j] += self.arr[i][k] * other.arr[k][j]
         return Matrix(prod)
+
+
     def __repr__(self):
 
         """
@@ -58,6 +64,7 @@ class Matrix:
         """
 
         return f"Matrix({self.arr})"
+
 
     def __str__(self):
         """

--- a/matrices.py
+++ b/matrices.py
@@ -55,14 +55,12 @@ class Matrix:
 
 
     def __repr__(self):
-
         """
         >>> import matrices as m
         >>> l=m.Matrix([[1,2])
         >>> l
         Matrix([[1,2]])
         """
-
         return f"Matrix({self.arr})"
 
 
@@ -73,7 +71,4 @@ class Matrix:
         >>> print(l)
         [[1 2]]
         """
-        arr = str(self.arr)
-        arr = arr.replace(",","")
-
-        return arr
+        return str(self.arr).replace(',', '')


### PR DESCRIPTION
- One-dimensional arrays (vectors) can now be successfully passed into the `Matrix` class.
- Fixed instance variable names. Variable names were previously only changed in the `__init__` method.
- Reverted the `adim` instance variable definition back to `len(arr[0])`, since `str(arr).count('[')` incorrectly counts the number of column vectors.
- Added in the ability to multiply a matrix by a scalar.